### PR TITLE
Pharo 12 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,19 +1,26 @@
 name: CI
 
 on: [ push, pull_request, workflow_dispatch ]
-          
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-9.0, Pharo64-8.0, Pharo64-7.0 ]
+        smalltalk: [ Pharo64-12 ]
+        experimental: [false]
+    continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.smalltalk }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
-          smalltalk-version: ${{ matrix.smalltalk }}
-      - run: smalltalkci -s ${{ matrix.smalltalk }}
+          smalltalk-image: ${{ matrix.smalltalk }}
+      - name: Run tests
+        run: smalltalkci -s ${{ matrix.smalltalk }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-        timeout-minutes: 1
+        timeout-minutes: 20
+

--- a/src/Neo-Console-Core/NeoConsole.class.st
+++ b/src/Neo-Console-Core/NeoConsole.class.st
@@ -8,38 +8,39 @@ I hold the last 3 results.
 I offer quick access to NeoConsoleEnvironment current and NeoConsoleStdio run.
 "
 Class {
-	#name : #NeoConsole,
-	#superclass : #Object,
+	#name : 'NeoConsole',
+	#superclass : 'Object',
 	#classVars : [
 		'History',
 		'Results'
 	],
-	#category : #'Neo-Console-Core'
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsole class >> clearResults [
 	^ self results 
 		atAllPut: nil; 
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsole class >> env [
 	^ NeoConsoleEnvironment current
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsole class >> history [
 	^ History ifNil: [ History := OrderedCollection new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsole class >> last [
 	^ self results last
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsole class >> lastResult: anObject [
 	| results |
 	results := self results.
@@ -50,22 +51,22 @@ NeoConsole class >> lastResult: anObject [
 	^ results
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsole class >> repl [
 	^ NeoConsoleStdio run
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsole class >> results [
 	^ Results ifNil: [ Results := Array new: 3 ]
 ]
 
-{ #category : #server }
+{ #category : 'server' }
 NeoConsole class >> startServer [
 	^ NeoConsoleTelnetServer new start
 ]
 
-{ #category : #server }
+{ #category : 'server' }
 NeoConsole class >> startServerOn: port [
 	^ NeoConsoleTelnetServer startOn: port
 ]

--- a/src/Neo-Console-Core/NeoConsoleAddCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleAddCommand.class.st
@@ -23,22 +23,23 @@ example1
 
 "
 Class {
-	#name : #NeoConsoleAddCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleAddCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleAddCommand class >> isSingleLine [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleAddCommand class >> prefix [
 	^ 'add'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleAddCommand >> execute [
 	| lines targetClass source |
 	(lines := self argument lines) ifEmpty: [ ^ result := self class comment ].
@@ -58,7 +59,7 @@ NeoConsoleAddCommand >> execute [
 				do: [ :exception | self logException: exception on: out ] ]
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleAddCommand >> on: input [
 	super on: input.
 	(self argument beginsWith: self class prefix)

--- a/src/Neo-Console-Core/NeoConsoleCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleCommand.class.st
@@ -4,21 +4,22 @@ I am NeoConsoleCommand. I describe a command that can be executed by the NeoCons
 The class comments of my subclasses are used as help texts in the command line interface.
 "
 Class {
-	#name : #NeoConsoleCommand,
-	#superclass : #Object,
+	#name : 'NeoConsoleCommand',
+	#superclass : 'Object',
 	#instVars : [
 		'arguments',
 		'result'
 	],
-	#category : 'Neo-Console-Core'
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand class >> defaultCommand [
 	^ NeoConsoleEvalCommand 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand class >> forLine: line [
 	| commandClass |
 	commandClass := self knownCommands 
@@ -27,12 +28,12 @@ NeoConsoleCommand class >> forLine: line [
 	^ commandClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleCommand class >> handlesLine: line [
 	^ line beginsWith: self prefix
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand class >> helpText [
 	^ String streamContents: [ :out |
 			out << self name; cr.
@@ -40,59 +41,59 @@ NeoConsoleCommand class >> helpText [
 				out space; space; << each; cr ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleCommand class >> isMultiLine [
 	^ self isSingleLine not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleCommand class >> isSingleLine [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand class >> knownCommands [
 	^ self subclasses
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand class >> prefix [
 	^ self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand >> argument [
 	^ arguments first
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand >> arguments [
 	^ arguments 
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleCommand >> execute [
 	self subclassResponsibility 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleCommand >> hasArguments [
 	^ arguments notNil and: [ arguments notEmpty ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleCommand >> logException: exception on: out [
 	out print: exception; cr.
 	exception signalerContext printDetails: out.
 	exception signalerContext sender debugStack: 8 on: out
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleCommand >> on: input [
 	arguments := Array with: input trimBoth
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommand >> result [
 	^ result
 ]

--- a/src/Neo-Console-Core/NeoConsoleCommandLineHandler.class.st
+++ b/src/Neo-Console-Core/NeoConsoleCommandLineHandler.class.st
@@ -27,22 +27,23 @@ Examples:
 
 "
 Class {
-	#name : #NeoConsoleCommandLineHandler,
-	#superclass : #CommandLineHandler,
-	#category : #'Neo-Console-Core'
+	#name : 'NeoConsoleCommandLineHandler',
+	#superclass : 'CommandLineHandler',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommandLineHandler class >> commandName [
 	^ 'NeoConsole'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleCommandLineHandler class >> description [
 	^ 'Invoke/start NeoConsole functionality like the repl (read-eval-print-loop)'
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 NeoConsoleCommandLineHandler >> activate [
 	self activateHelpWithoutArguments
 		ifTrue: [ ^ self ].
@@ -55,7 +56,7 @@ NeoConsoleCommandLineHandler >> activate [
 	self exitFailure: 'Unknown subcommand: ' , self arguments first
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 NeoConsoleCommandLineHandler >> get [
 	self arguments size = 1
 		ifTrue: [
@@ -72,13 +73,13 @@ NeoConsoleCommandLineHandler >> get [
 					do: [ self exitFailure: 'unknown metric: ' , self arguments second ] ]
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 NeoConsoleCommandLineHandler >> repl [
 	NeoConsole repl.
 	self exitSuccess
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 NeoConsoleCommandLineHandler >> server [
 	self stdout
 		nextPutAll: 'Started';

--- a/src/Neo-Console-Core/NeoConsoleDescribeCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleDescribeCommand.class.st
@@ -18,22 +18,23 @@ describe
 
 "
 Class {
-	#name : #NeoConsoleDescribeCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleDescribeCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleDescribeCommand class >> handlesLine: line [
 	^ line first = $= or: [ super handlesLine: line ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleDescribeCommand class >> prefix [
 	^ 'describe'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleDescribeCommand >> execute [
 	| object |
 	object := NeoConsole last.
@@ -55,14 +56,14 @@ NeoConsoleDescribeCommand >> execute [
 						out print: index; << ': '; << (self printLimited: [ object at: index ]); cr ] ] ] ]
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleDescribeCommand >> on: input [
 	super on: input.
 	arguments := self argument findTokens: Character separators.
 	arguments := arguments allButFirst 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleDescribeCommand >> printLimited: valuable [ 
 	^ [ valuable value printStringLimitedTo: 64 ] on: Error do: [ '<error while printing>' ]
 ]

--- a/src/Neo-Console-Core/NeoConsoleEnvironment.class.st
+++ b/src/Neo-Console-Core/NeoConsoleEnvironment.class.st
@@ -19,28 +19,29 @@ Keys are stored as symbols.
 
 "
 Class {
-	#name : #NeoConsoleEnvironment,
-	#superclass : #Object,
+	#name : 'NeoConsoleEnvironment',
+	#superclass : 'Object',
 	#instVars : [
 		'environment'
 	],
 	#classVars : [
 		'UniqueInstance'
 	],
-	#category : 'Neo-Console-Core'
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment class >> current [
 	^ UniqueInstance ifNil: [ UniqueInstance := self new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment class >> default [
 	^ self current
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment >> at: key [
 	"Return my value for key.
 	Signal NotFound if I do not know key."
@@ -48,7 +49,7 @@ NeoConsoleEnvironment >> at: key [
 	^ environment at: key
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment >> at: key ifAbsent: block [
 	"Return my value for key.
 	Return the value of evaluating block in case I do not know key."
@@ -56,7 +57,7 @@ NeoConsoleEnvironment >> at: key ifAbsent: block [
 	^ environment at: key ifAbsent: block
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment >> at: key ifAbsentPut: block [
 	"Return my value for key.
 	Store and return the value of evaluating block in case I do not know key."
@@ -64,7 +65,7 @@ NeoConsoleEnvironment >> at: key ifAbsentPut: block [
 	^ environment at: key ifAbsentPut: block
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment >> at: key ifPresent: block [
 	"Return the value of evaluating block with my value for key.
 	Return self, in effect do nothing, in case I do not know key."
@@ -72,7 +73,7 @@ NeoConsoleEnvironment >> at: key ifPresent: block [
 	^ environment at: key ifPresent: block
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment >> at: key put: value [
 	"I will store value for key.
 	Return value."
@@ -80,34 +81,34 @@ NeoConsoleEnvironment >> at: key put: value [
 	^ environment at: key asSymbol put: value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleEnvironment >> includesKey: key [
 	^ environment includesKey: key
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleEnvironment >> initialize [
 	environment := Dictionary new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment >> keys [
 	^ environment keys
 ]
 
-{ #category : #enumeration }
+{ #category : 'enumeration' }
 NeoConsoleEnvironment >> keysAndValuesDo: block [
 	environment keysAndValuesDo: block
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleEnvironment >> loadOSEnvironment [
 	OSPlatform current environment 
 		keysAndValuesDo: [ :key :value | 
 			self at: key put: value ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEnvironment >> removeKey: key [
 	"Remove any value I have stored under key.
 	Do not fail if key is not present."

--- a/src/Neo-Console-Core/NeoConsoleEvalCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleEvalCommand.class.st
@@ -18,22 +18,23 @@ eval 1+2
 - evaluate the multi line expression, doubling the numbers 1 to 10 in a collection
 "
 Class {
-	#name : #NeoConsoleEvalCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleEvalCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleEvalCommand class >> isSingleLine [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEvalCommand class >> prefix [
 	^ 'eval'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleEvalCommand >> execute [
 	result := String 
 		streamContents: [ :out | 
@@ -50,14 +51,14 @@ NeoConsoleEvalCommand >> execute [
 		ifFalse: [ result := result , ' ... (truncated) ...' ]
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleEvalCommand >> on: input [
 	super on: input.
 	(self argument beginsWith: self class prefix)
 		ifTrue: [ arguments := Array with: (self argument allButFirst: self class prefix size) trimBoth ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleEvalCommand >> outputLimit [
 	^ 16384
 ]

--- a/src/Neo-Console-Core/NeoConsoleGetCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleGetCommand.class.st
@@ -23,17 +23,18 @@ get status
 - list all metrics containing 'status'
 "
 Class {
-	#name : #NeoConsoleGetCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleGetCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleGetCommand class >> prefix [
 	^ 'get'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleGetCommand >> execute [
 	self hasArguments 
 		ifTrue: [ 
@@ -52,14 +53,14 @@ NeoConsoleGetCommand >> execute [
 				self renderMetrics: NeoConsoleMetric knownMetrics on: out ] ]
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleGetCommand >> on: input [
 	super on: input.
 	arguments := self argument findTokens: Character separators.
 	arguments := arguments allButFirst 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleGetCommand >> renderMetrics: metrics on: out [
 	(metrics sorted: #name ascending)
 		do: [ :each | out space; space; << each name; << ' - '; << each description ] 

--- a/src/Neo-Console-Core/NeoConsoleHaltCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleHaltCommand.class.st
@@ -7,17 +7,18 @@ halt - Quit the image
 
 "
 Class {
-	#name : #NeoConsoleHaltCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : #'Neo-Console-Core'
+	#name : 'NeoConsoleHaltCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleHaltCommand class >> prefix [
 	^ 'halt'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleHaltCommand >> execute [
 	Smalltalk quitPrimitive 
 ]

--- a/src/Neo-Console-Core/NeoConsoleHelpCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleHelpCommand.class.st
@@ -7,22 +7,23 @@ help - list all commands
 help <command> - print help about <command>
 "
 Class {
-	#name : #NeoConsoleHelpCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleHelpCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleHelpCommand class >> handlesLine: line [
 	^ line first = $? or: [ super handlesLine: line ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleHelpCommand class >> prefix [
 	^ 'help'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleHelpCommand >> execute [
 	self hasArguments 
 		ifTrue: [ 
@@ -41,7 +42,7 @@ NeoConsoleHelpCommand >> execute [
 					separatedBy: [ out cr ] ] ]
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleHelpCommand >> on: input [
 	super on: input.
 	arguments := self argument findTokens: Character separators.

--- a/src/Neo-Console-Core/NeoConsoleHistoryCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleHistoryCommand.class.st
@@ -11,22 +11,23 @@ history last - execute the last input again
 history ! - execute the last input again
 "
 Class {
-	#name : #NeoConsoleHistoryCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleHistoryCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleHistoryCommand class >> handlesLine: line [
 	^ line first = $! or: [ super handlesLine: line ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleHistoryCommand class >> prefix [
 	^ 'history'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleHistoryCommand >> execute [
 	self hasArguments
 		ifTrue: [
@@ -41,7 +42,7 @@ NeoConsoleHistoryCommand >> execute [
 		ifFalse: [ self historySummary ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleHistoryCommand >> executeHistoryAt: index [
 	| input evalCommand |
 	[ 
@@ -53,7 +54,7 @@ NeoConsoleHistoryCommand >> executeHistoryAt: index [
 		do: [ result := 'no history item @ ' , index asString ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleHistoryCommand >> executeHistoryLast [
 	| size |
 	size := NeoConsole history size.
@@ -62,20 +63,20 @@ NeoConsoleHistoryCommand >> executeHistoryLast [
 		ifFalse: [ self executeHistoryAt: size ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleHistoryCommand >> history [
 	result := String streamContents: [ :out |
 		1 to: NeoConsole history size do: [ :each |
 			out print: each; << ': '; << (NeoConsole history at: each); cr ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleHistoryCommand >> historyClear [
 	NeoConsole history removeAll.
 	result := 'history cleared'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleHistoryCommand >> historySummary [
 	result := String streamContents: [ :out | | size |
 		size := NeoConsole history size.
@@ -83,12 +84,12 @@ NeoConsoleHistoryCommand >> historySummary [
 			out print: each; << ': '; << (NeoConsole history at: each); cr ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleHistoryCommand >> historySummarySize [
 	^ 10
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleHistoryCommand >> on: input [
 	super on: input.
 	self argument first = $!

--- a/src/Neo-Console-Core/NeoConsoleMetric.class.st
+++ b/src/Neo-Console-Core/NeoConsoleMetric.class.st
@@ -4,8 +4,8 @@ I am NeoConsoleMetric. I represent a named metric with a description. I evaluate
 My class side holds a list of #knownMetrics.
 "
 Class {
-	#name : #NeoConsoleMetric,
-	#superclass : #Object,
+	#name : 'NeoConsoleMetric',
+	#superclass : 'Object',
 	#instVars : [
 		'name',
 		'description',
@@ -14,22 +14,23 @@ Class {
 	#classVars : [
 		'KnownMetrics'
 	],
-	#category : 'Neo-Console-Core'
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric class >> add: metric [
 	^ self knownMetrics 
 		removeAllSuchThat: [ :each | each name = metric name ]; 
 		add: metric
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric class >> addNamed: metricName description: description reader: valueable [
 	^ self add: (self named: metricName description: description reader: valueable)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleMetric class >> initialize [
 	"self initialize"
 	
@@ -39,14 +40,8 @@ NeoConsoleMetric class >> initialize [
 	"last update: 2015-08-17"
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleMetric class >> initializeChronologyMetrics [
-	self addNamed: 'system.uptime' 
-		description: 'Image uptime human readeable' 
-		reader: [ (self sessionAge roundTo: 1 minute) humanReadablePrintString ].	
-	self addNamed: 'system.uptimeseconds' 
-		description: 'Image uptime seconds' 
-		reader: [ self sessionAge asSeconds ].	
 	self addNamed: 'system.date' 
 		description: 'Current date' 
 		reader: [ Date today printString ].
@@ -58,7 +53,7 @@ NeoConsoleMetric class >> initializeChronologyMetrics [
 		reader: [ DateAndTime now printString ].
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleMetric class >> initializeMemoryMetrics [
 	self addNamed: 'memory.total' 
 		description: 'Total allocated memory' 
@@ -71,7 +66,7 @@ NeoConsoleMetric class >> initializeMemoryMetrics [
 		reader: [ Smalltalk garbageCollect. self memoryFree ].
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleMetric class >> initializeMetrics [
 	self initializeSystemStatusMetric.
 	self initializeMemoryMetrics.
@@ -80,7 +75,7 @@ NeoConsoleMetric class >> initializeMetrics [
 	self initializeVersionMetrics.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleMetric class >> initializeProcessMetrics [
 	self addNamed: 'process.count' 
 		description: 'Current process count' 
@@ -90,7 +85,7 @@ NeoConsoleMetric class >> initializeProcessMetrics [
 		reader: [ String cr join: ((Process allSubInstances reject: #isTerminated) collect: #name as: Array) ].
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleMetric class >> initializeSystemStatusMetric [
 	self addNamed: 'system.status' 
 		description: 'Simple system status' 
@@ -101,44 +96,49 @@ NeoConsoleMetric class >> initializeSystemStatusMetric [
 				(self memoryFree / self memoryTotal * 100.0) printShowingDecimalPlaces: 2 } ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleMetric class >> initializeVersionMetrics [
-	self addNamed: 'system.version' 
-		description: 'Image version info' 
+
+	self
+		addNamed: 'system.version'
+		description: 'Image version info'
 		reader: [ SystemVersion current ].
-	self addNamed: 'system.mcversions' 
-		description: 'Monticello packages version info' 
-		reader: [ String cr join: (MCWorkingCopy allManagers collect: #description) sorted ].
+	self
+		addNamed: 'system.mcversions'
+		description: 'Monticello packages version info'
+		reader: [
+			String cr join:
+				(MCWorkingCopy allWorkingCopies collect: #description) sorted ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric class >> knownMetrics [
 	^ KnownMetrics ifNil: [ KnownMetrics := OrderedCollection new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric class >> matching: pattern [
 	| patternToSearchFor |
 	patternToSearchFor := (pattern includes: $*) ifTrue: [ pattern ] ifFalse: [ '*' , pattern , '*' ]. 
 	^ self knownMetrics select: [ :each | patternToSearchFor match: each name ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleMetric class >> memoryFree [
 	^ Smalltalk vm freeOldSpaceSize + Smalltalk vm edenSpaceSize - Smalltalk vm youngSpaceSize
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleMetric class >> memoryTotal [
 	^ Smalltalk vm memorySize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric class >> named: metricName [
 	^ self knownMetrics detect: [ :each | each name = metricName ] ifNone: [ NotFound signalFor: metricName ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 NeoConsoleMetric class >> named: metricName description: description reader: valueable [
 	^ self new
 		name: metricName;
@@ -147,14 +147,7 @@ NeoConsoleMetric class >> named: metricName description: description reader: val
 		yourself
 ]
 
-{ #category : #private }
-NeoConsoleMetric class >> sessionAge [
-	^ (Smalltalk includesKey: #Session)
-		ifTrue: [ (Smalltalk at: #Session) current age ]
-		ifFalse: [ DateAndTime now - (Smalltalk at: #SessionManager) default currentSession creationTime ]
-]
-
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 NeoConsoleMetric class >> startUp [
 	"This message is sent to registered classes when the system is coming up."
 	
@@ -162,43 +155,43 @@ NeoConsoleMetric class >> startUp [
  
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric >> description [
 	^ description
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric >> description: string [
 	description := string
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric >> name: string [
 	name := string
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 NeoConsoleMetric >> printOn: stream [
 	super printOn: stream.
 	stream nextPut: $(; << name; nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric >> reader [
 	^ reader
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric >> reader: aValuable [
 	reader := aValuable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleMetric >> value [
 	^ reader value
 ]

--- a/src/Neo-Console-Core/NeoConsoleMetricDelegate.class.st
+++ b/src/Neo-Console-Core/NeoConsoleMetricDelegate.class.st
@@ -13,12 +13,13 @@ To list all metrics GET /metrics
 
 "
 Class {
-	#name : #NeoConsoleMetricDelegate,
-	#superclass : #Object,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleMetricDelegate',
+	#superclass : 'Object',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleMetricDelegate class >> startOn: port [
 	"self startOn: 1707"
 	
@@ -30,7 +31,7 @@ NeoConsoleMetricDelegate class >> startOn: port [
 		yourself
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleMetricDelegate >> handleRequest: request [
 	((#(GET HEAD) includes: request method) and: [ request uri firstPathSegment = #metrics ])
 		ifFalse: [ ^ ZnResponse notFound: request uri ].
@@ -41,7 +42,7 @@ NeoConsoleMetricDelegate >> handleRequest: request [
 		do: [ ZnResponse notFound: request uri ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleMetricDelegate >> okResponse: text [
 	| output |
 	output := String new: text size + 10 streamContents: [ :out |
@@ -50,7 +51,7 @@ NeoConsoleMetricDelegate >> okResponse: text [
 	^ ZnResponse ok: (ZnEntity text: output)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleMetricDelegate >> responseForKnowMetrics [
 	| metrics text |
 	metrics := NeoConsoleMetric knownMetrics sorted: #name ascending.
@@ -59,7 +60,7 @@ NeoConsoleMetricDelegate >> responseForKnowMetrics [
 	^ self okResponse: text
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleMetricDelegate >> responseForMetricNamed: metricName [
 	| metric |
 	metric := NeoConsoleMetric named: metricName.

--- a/src/Neo-Console-Core/NeoConsoleQuitCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleQuitCommand.class.st
@@ -7,22 +7,23 @@ quit - Quit the REPL
 
 "
 Class {
-	#name : #NeoConsoleQuitCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleQuitCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleQuitCommand class >> handlesLine: line [
 	^ line first = Character end "Ctrl-D" or: [ super handlesLine: line ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleQuitCommand class >> prefix [
 	^ 'quit'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleQuitCommand >> execute [
 	result := 'Bye!'.
 	^ nil

--- a/src/Neo-Console-Core/NeoConsoleSaveCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleSaveCommand.class.st
@@ -4,17 +4,18 @@ Save the image
 save - save the image and quit the REPL
 "
 Class {
-	#name : #NeoConsoleSaveCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : #'Neo-Console-Core'
+	#name : 'NeoConsoleSaveCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleSaveCommand class >> prefix [
 	^ 'save'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleSaveCommand >> execute [
 	| resuming |
 	resuming := Smalltalk snapshot: true andQuit: false.

--- a/src/Neo-Console-Core/NeoConsoleShowCommand.class.st
+++ b/src/Neo-Console-Core/NeoConsoleShowCommand.class.st
@@ -22,17 +22,18 @@ show Character class>>#euro
 
 "
 Class {
-	#name : #NeoConsoleShowCommand,
-	#superclass : #NeoConsoleCommand,
-	#category : 'Neo-Console-Core'
+	#name : 'NeoConsoleShowCommand',
+	#superclass : 'NeoConsoleCommand',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleShowCommand class >> prefix [
 	^ 'show'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleShowCommand >> execute [
 	self hasArguments 
 		ifTrue: [ | thing |
@@ -49,7 +50,7 @@ NeoConsoleShowCommand >> execute [
 			result := self class comment ]
 ]
 
-{ #category : #'initialization-release' }
+{ #category : 'initialization-release' }
 NeoConsoleShowCommand >> on: input [
 	super on: input.
 	(self argument beginsWith: self class prefix)

--- a/src/Neo-Console-Core/NeoConsoleStdio.class.st
+++ b/src/Neo-Console-Core/NeoConsoleStdio.class.st
@@ -6,12 +6,13 @@ NeoConsoleStdio offers a command line interface to a Pharo image over Stdio.
 End with quit or an empty line.
 "
 Class {
-	#name : #NeoConsoleStdio,
-	#superclass : #Object,
-	#category : #'Neo-Console-Core'
+	#name : 'NeoConsoleStdio',
+	#superclass : 'Object',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 NeoConsoleStdio class >> nextLineFrom: stdin [
 	"Read a CR, LF or CRLF terminated line from stdin, 
 	returning the contents of the line without the EOL. 
@@ -39,12 +40,12 @@ NeoConsoleStdio class >> nextLineFrom: stdin [
 
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleStdio class >> run [
 	^ self new run
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleStdio >> executeRequestResponseLoop [
 	| in out command executeResult |
 	in := Stdio stdin.
@@ -60,12 +61,12 @@ NeoConsoleStdio >> executeRequestResponseLoop [
 		executeResult notNil ] whileTrue
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 NeoConsoleStdio >> printOn: stream [
 	stream nextPutAll: self class name
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleStdio >> readInputFrom: stdin [
 	| input line commandClass |
 	line := (self class nextLineFrom: stdin) trimBoth.
@@ -82,13 +83,13 @@ NeoConsoleStdio >> readInputFrom: stdin [
 	^ commandClass new on: input contents; yourself
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleStdio >> run [
 	self executeRequestResponseLoop 
 
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleStdio >> writeOutput: string to: stream [
 	string isEmptyOrNil
 		ifTrue: [ ^ self ].

--- a/src/Neo-Console-Core/NeoConsoleTelnetServer.class.st
+++ b/src/Neo-Console-Core/NeoConsoleTelnetServer.class.st
@@ -14,8 +14,8 @@ End with quit or an empty line.
 Security warning: this service opens up your image for access to those with access to your local network (i.e. those logged in to your machine), without any further authenication, allowing them to do absolutely anything. Think and make sure that you know what you are doing.
 "
 Class {
-	#name : #NeoConsoleTelnetServer,
-	#superclass : #Object,
+	#name : 'NeoConsoleTelnetServer',
+	#superclass : 'Object',
 	#instVars : [
 		'port',
 		'process',
@@ -24,27 +24,28 @@ Class {
 	#classVars : [
 		'ManagedServers'
 	],
-	#category : #'Neo-Console-Core'
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 NeoConsoleTelnetServer class >> initialize [
 	SessionManager default registerNetworkClassNamed: self name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTelnetServer class >> managedServers [
 	^ ManagedServers ifNil: [ ManagedServers := IdentitySet new ]
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 NeoConsoleTelnetServer class >> register: server [
 	"Arrange for server to be sent start/stop on system startUp/shutDown"
 	
 	self managedServers add: server
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 NeoConsoleTelnetServer class >> shutDown: quiting [
 	"Our system shutDown hook: stop all servers we manage"
 	
@@ -53,7 +54,7 @@ NeoConsoleTelnetServer class >> shutDown: quiting [
 			self managedServers do: [ :each | each stop: false ] ]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleTelnetServer class >> startOn: port [
 	"self startOn: 4999"
 	
@@ -62,7 +63,7 @@ NeoConsoleTelnetServer class >> startOn: port [
 		start
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 NeoConsoleTelnetServer class >> startUp: resuming [
 	"Our system startUp hook: start all servers we manage.
 	We do this using deferred startup actions to allow normal error handling."
@@ -73,14 +74,14 @@ NeoConsoleTelnetServer class >> startUp: resuming [
 				self managedServers do: [ :each | each start ] ] ]
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 NeoConsoleTelnetServer class >> unregister: server [
 	"No longer send server start/stop on system startUp/shutDown"
 	
 	self managedServers remove: server ifAbsent: [ ]
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleTelnetServer >> executeRequestResponseLoopOn: stream [
 	| in out command executeResult |
 	in := ZnCharacterReadStream on: stream.
@@ -96,7 +97,7 @@ NeoConsoleTelnetServer >> executeRequestResponseLoopOn: stream [
 		executeResult notNil ] whileTrue
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleTelnetServer >> initializeServerSocket [
 	serverSocket := Socket newTCP.
 	serverSocket setOption: 'TCP_NODELAY' value: 1.
@@ -108,14 +109,14 @@ NeoConsoleTelnetServer >> initializeServerSocket [
 		ifFalse: [ self error: 'Cannot create socket on port ' , self port printString ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleTelnetServer >> isRunning [
 	"Return true when I am running"
 	
 	^ process notNil and: [ serverSocket notNil ]
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleTelnetServer >> listenLoop [
 	"We create a listening Socket, then wait for a connection.
 	After each connection we also check that the listening Socket is still valid 
@@ -132,17 +133,17 @@ NeoConsoleTelnetServer >> listenLoop [
 		ifCurtailed: [ self releaseServerSocket ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTelnetServer >> port [
 	^ port ifNil: [ port := 4999 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTelnetServer >> port: integer [
 	port := integer
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 NeoConsoleTelnetServer >> printOn: stream [
 	super printOn: stream.
 	stream << $(.
@@ -150,7 +151,7 @@ NeoConsoleTelnetServer >> printOn: stream [
 	stream << $)
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleTelnetServer >> readInputFrom: stream [
 	| input lineReader line commandClass |
 	lineReader := ZnFastLineReader on: stream.
@@ -168,14 +169,14 @@ NeoConsoleTelnetServer >> readInputFrom: stream [
 	^ commandClass new on: input contents; yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleTelnetServer >> releaseServerSocket [
 	(Delay forMilliseconds: 10) wait.
 	serverSocket destroy.
 	serverSocket := nil
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleTelnetServer >> serveConnectionsOn: listeningSocket [
 	"We wait up to acceptWaitTimeout seconds for an incoming connection.
 	If we get one we wrap it in a SocketStream and #executeRequestResponseLoopOn: on it"
@@ -191,12 +192,12 @@ NeoConsoleTelnetServer >> serveConnectionsOn: listeningSocket [
 				named: self workerProcessName 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTelnetServer >> serverProcessName [
 	^ self class name asString , ' port ' , self port asString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleTelnetServer >> socketStreamOn: socket [
 	^ (ZdcSocketStream on: socket)
 		binary;
@@ -206,7 +207,7 @@ NeoConsoleTelnetServer >> socketStreamOn: socket [
 		yourself
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleTelnetServer >> start [
 	self stop.
 	self class register: self.
@@ -217,12 +218,12 @@ NeoConsoleTelnetServer >> start [
 		named: self serverProcessName
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleTelnetServer >> stop [
 	self stop: true
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 NeoConsoleTelnetServer >> stop: unregister [
 	unregister ifTrue: [ self class unregister: self ].
 	self isRunning ifFalse: [ ^ self ].
@@ -231,17 +232,17 @@ NeoConsoleTelnetServer >> stop: unregister [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTelnetServer >> timeout [
 	^ 60
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTelnetServer >> workerProcessName [
 	^ self serverProcessName, ' Connection Handler'
 ]
 
-{ #category : #protocol }
+{ #category : 'protocol' }
 NeoConsoleTelnetServer >> writeOutput: string to: stream [
 	string isEmptyOrNil
 		ifTrue: [ ^ self ].

--- a/src/Neo-Console-Core/NeoConsoleTelnetServerTests.class.st
+++ b/src/Neo-Console-Core/NeoConsoleTelnetServerTests.class.st
@@ -2,32 +2,33 @@
 I am NeoConsoleTelnetServerTests, holding functional unit tests for NeoConsoleTelnetServer
 "
 Class {
-	#name : #NeoConsoleTelnetServerTests,
-	#superclass : #TestCase,
+	#name : 'NeoConsoleTelnetServerTests',
+	#superclass : 'TestCase',
 	#instVars : [
 		'server'
 	],
-	#category : #'Neo-Console-Core'
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTelnetServerTests >> localhost [
 	^ #[127 0 0 1] asSocketAddress
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 NeoConsoleTelnetServerTests >> setUp [ 
 	super setUp.
 	server := NeoConsoleTelnetServer new start
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 NeoConsoleTelnetServerTests >> tearDown [
 	server stop.
 	super tearDown 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleTelnetServerTests >> testConnect [
 	| connection in out line |
 	connection := ZdcSocketStream openConnectionToHost: self localhost port: server port timeout: 10.
@@ -43,7 +44,7 @@ NeoConsoleTelnetServerTests >> testConnect [
 	connection close
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleTelnetServerTests >> testEvalSum [
 	| connection in out line x y |
 	connection := ZdcSocketStream openConnectionToHost: self localhost port: server port timeout: 10.
@@ -62,7 +63,7 @@ NeoConsoleTelnetServerTests >> testEvalSum [
 	connection close
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleTelnetServerTests >> testGetSystemTimestamp [
 	| connection in out line |
 	connection := ZdcSocketStream openConnectionToHost: self localhost port: server port timeout: 10.
@@ -77,7 +78,7 @@ NeoConsoleTelnetServerTests >> testGetSystemTimestamp [
 	connection close
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NeoConsoleTelnetServerTests >> testSumMultiline [
 	| connection in out line x y |
 	connection := ZdcSocketStream openConnectionToHost: self localhost port: server port timeout: 10.

--- a/src/Neo-Console-Core/NeoConsoleTests.class.st
+++ b/src/Neo-Console-Core/NeoConsoleTests.class.st
@@ -18,7 +18,7 @@ NeoConsoleTests >> testEnvironment [
 	self deny: (NeoConsole env includesKey: #SECRET).
 	
 	NeoConsole env loadOSEnvironment.
-	self assert: (NeoConsole env includesKey: #PATH).
+	self assert: ((NeoConsole env includesKey: #PATH) or: (NeoConsole env includesKey: #Path)).
 	
 
 	

--- a/src/Neo-Console-Core/NeoConsoleTests.class.st
+++ b/src/Neo-Console-Core/NeoConsoleTests.class.st
@@ -2,12 +2,13 @@
 I am NeoConsoleTests, containing some functional tests for NeoConsole.
 "
 Class {
-	#name : #NeoConsoleTests,
-	#superclass : #TestCase,
-	#category : #'Neo-Console-Core'
+	#name : 'NeoConsoleTests',
+	#superclass : 'TestCase',
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 NeoConsoleTests >> testEnvironment [
 	NeoConsole env at: #SECRET ifPresent: [ self fail ].
 	NeoConsole env at: #SECRET put: 42 asWords.
@@ -23,7 +24,7 @@ NeoConsoleTests >> testEnvironment [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 NeoConsoleTests >> testMetrics [
 	NeoConsoleMetric knownMetrics do: [ :each |
 		self deny: each value isNil.

--- a/src/Neo-Console-Core/NeoConsoleTranscript.class.st
+++ b/src/Neo-Console-Core/NeoConsoleTranscript.class.st
@@ -5,15 +5,16 @@ I am NeoConsoleTranscript, a NonInteractiveTranscript that writes to a dated fil
 
 "
 Class {
-	#name : #NeoConsoleTranscript,
-	#superclass : #NonInteractiveTranscript,
+	#name : 'NeoConsoleTranscript',
+	#superclass : 'NonInteractiveTranscript',
 	#instVars : [
 		'date'
 	],
-	#category : 'Neo-Console-Core'
+	#category : 'Neo-Console-Core',
+	#package : 'Neo-Console-Core'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 NeoConsoleTranscript class >> defaultLogFileName [
 	"The default file name that will be used to write to.
 	This needs to have a slot where the date will come."
@@ -21,7 +22,7 @@ NeoConsoleTranscript class >> defaultLogFileName [
 	^ 'PharoTranscript-{1}.log'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTranscript >> fileNameWithDate [
 	| newName |
 	newName := self fileName format: { date yyyymmdd }.
@@ -31,13 +32,13 @@ NeoConsoleTranscript >> fileNameWithDate [
 	^ newName
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 NeoConsoleTranscript >> initialize [
 	super initialize.
 	date := Date today
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 NeoConsoleTranscript >> initializeStream [
 	"Open the file stream that I write to or connect to #stdout/#stderr.
 	I will use the platform line end convention.
@@ -55,7 +56,7 @@ NeoConsoleTranscript >> initializeStream [
 	^ stream := ZnCharacterWriteStream on: binaryStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NeoConsoleTranscript >> stream [ 
 	"Overwritten to check if the date changed on each access"
 	

--- a/src/Neo-Console-Core/package.st
+++ b/src/Neo-Console-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Neo-Console-Core' }
+Package { #name : 'Neo-Console-Core' }


### PR DESCRIPTION
- Updated CI.yml for testing on Pharo 12.
- Removed #sessionAge using metrics since WorkingSession no longer has #creationTime.
- Fixed NeoConsoleTests>>testEnvironment to not cause an error on Windows 11 ('Path' is used for path variable).